### PR TITLE
Pass the Context through to the emitter function

### DIFF
--- a/alog_test.go
+++ b/alog_test.go
@@ -27,7 +27,7 @@ func Example() {
 
 func Example_levels() {
 	ctx := context.Background()
-	l := New(WithEmitter(func(e *Entry) {
+	l := New(WithEmitter(EmitterFunc(func(ctx context.Context, e *Entry) {
 		for _, p := range e.Tags {
 			if p[0] != "level" {
 				continue
@@ -42,7 +42,7 @@ func Example_levels() {
 				return
 			}
 		}
-	}))
+	})))
 	error := AddTags(ctx, "level", "error")
 	info := AddTags(ctx, "level", "info")
 	debug := AddTags(ctx, "level", "debug")
@@ -67,9 +67,9 @@ func ExampleNew() {
 }
 
 func ExampleWithEmitter() {
-	dumper := func(e *Entry) {
+	dumper := EmitterFunc(func(ctx context.Context, e *Entry) {
 		fmt.Printf("%v %s\n", e.Tags, e.Msg)
-	}
+	})
 	ctx := context.Background()
 	l := New(WithEmitter(dumper), WithFile())
 

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module "github.com/vimeo/alog"
+module github.com/vimeo/alog/v2

--- a/options.go
+++ b/options.go
@@ -31,7 +31,7 @@ type Option func(*Logger)
 // with additional guarentees that every entry generates a single Write call,
 // and calls are serialized.
 func To(w io.Writer) Option {
-	return func(l *Logger) { l.emit = l.EmitText(&out{Writer: w}) }
+	return func(l *Logger) { l.emitter = l.EmitText(&out{Writer: w}) }
 }
 
 // out is a wrapper to guarentee serialized access to the inner Writer.
@@ -90,6 +90,6 @@ func WithUTC() Option {
 // line.
 //
 // Calls to f are not synchronized.
-func WithEmitter(f func(e *Entry)) Option {
-	return func(l *Logger) { l.emit = f }
+func WithEmitter(e Emitter) Option {
+	return func(l *Logger) { l.emitter = e }
 }


### PR DESCRIPTION
This requires bumping the major version to v2.

Also adds Emitter and EmitterFunc types to make the API a bit cleaner.