### PR TITLE
gkelog: add WithWriters() option

### DIFF
--- a/emitter/gkelog/emitter.go
+++ b/emitter/gkelog/emitter.go
@@ -322,11 +322,15 @@ func Emitter(opt ...Option) alog.Emitter {
 	for _, option := range opt {
 		option(o)
 	}
-	if o.writer == nil {
-		o.writer = os.Stderr
+	if o.reqWriter == nil {
+		o.reqWriter = os.Stdout
+	}
+	if o.appWriter == nil {
+		o.appWriter = os.Stderr
 	}
 
-	wOut := internal.NewSerializedWriter(o.writer)
+	wReq := internal.NewSerializedWriter(o.reqWriter)
+	wApp := internal.NewSerializedWriter(o.appWriter)
 
 	return alog.EmitterFunc(func(ctx context.Context, e *alog.Entry) {
 		b := internal.GetBuffer()
@@ -378,6 +382,10 @@ func Emitter(opt ...Option) alog.Emitter {
 
 		b.WriteString("}\n")
 
-		wOut.Write(b.Bytes())
+		if ctx.Value(requestKey) == nil {
+			wApp.Write(b.Bytes())
+		} else {
+			wReq.Write(b.Bytes())
+		}
 	})
 }

--- a/emitter/gkelog/emitter_test.go
+++ b/emitter/gkelog/emitter_test.go
@@ -200,3 +200,24 @@ func TestLatency(t *testing.T) {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)
 	}
 }
+
+func TestWriters(t *testing.T) {
+	b0 := &bytes.Buffer{}
+	b1 := &bytes.Buffer{}
+	ctx := context.Background()
+	l := alog.New(alog.WithEmitter(Emitter(WithWriters(b0, b1))), zeroTimeOpt)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rctx := WithRequestStatus(WithRequest(ctx, req), http.StatusOK)
+
+	b0.WriteString("b0: ")
+	l.Print(rctx, "test")
+	b1.WriteString("b1: ")
+	l.Print(ctx, "test")
+
+	want := `b0: {"time":"0001-01-01T00:00:00Z", "httpRequest":{"status":200, "requestMethod":"GET", "requestUrl":"/test"}, "message":"test"}` + "\n" + `b1: {"time":"0001-01-01T00:00:00Z", "message":"test"}` + "\n"
+	got := b0.String() + b1.String()
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}

--- a/emitter/gkelog/options.go
+++ b/emitter/gkelog/options.go
@@ -6,7 +6,8 @@ import (
 
 // Options holds option values.
 type Options struct {
-	writer    io.Writer
+	reqWriter io.Writer
+	appWriter io.Writer
 	shortfile bool
 }
 
@@ -17,7 +18,22 @@ type Option func(*Options)
 
 // WithWriter sets the writer to use for log output.
 func WithWriter(w io.Writer) Option {
-	return func(o *Options) { o.writer = w }
+	return func(o *Options) {
+		o.reqWriter = w
+		o.appWriter = w
+	}
+}
+
+// WithWriters sets the writers to use for log output.
+//
+// req is used for log entries that have a Request.
+// app is used for all other log entries.
+// In GKE the typical usage would be WithWriters(os.Stdout, os.Stderr).
+func WithWriters(req io.Writer, app io.Writer) Option {
+	return func(o *Options) {
+		o.reqWriter = req
+		o.appWriter = app
+	}
 }
 
 // WithShortFile indicates to only use the filename instead of the full file


### PR DESCRIPTION
Allows setting seperate app and request logs for the same emitter.
The default will be to use stdout for request logs and stderr for
app logs. Using WithWriter() retains the previous behavior by
setting both the app and request logs to use the specified Writer.