### PR TITLE
jsonlog: remove duplicate tags from output

### DIFF
--- a/emitter/jsonlog/emitter.go
+++ b/emitter/jsonlog/emitter.go
@@ -108,7 +108,14 @@ func Emitter(w io.Writer, opt ...Option) alog.Emitter {
 
 		if len(e.Tags) > 0 {
 			b.WriteString(`"tags":{`)
+			tagClean := make(map[string]int, len(e.Tags))
 			for i, tag := range e.Tags {
+				tagClean[tag[0]] = i
+			}
+			for i, tag := range e.Tags {
+				if tagClean[tag[0]] != i {
+					continue
+				}
 				jsonString(b, tag[0])
 				b.WriteByte(':')
 				jsonString(b, tag[1])

--- a/emitter/jsonlog/emitter_test.go
+++ b/emitter/jsonlog/emitter_test.go
@@ -3,6 +3,7 @@ package jsonlog
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -19,7 +20,7 @@ func TestEmitter(t *testing.T) {
 	ctx = alog.AddTags(ctx, "allthese", "tags", "andanother", "tag")
 	l.Print(ctx, "test")
 
-	want := `{"timestamp":"0001-01-01T00:00:00.000000000Z", "caller":"emitter_test.go:20", "tags":{"allthese":"tags", "andanother":"tag"}, "message":"test"}` + "\n"
+	want := `{"timestamp":"0001-01-01T00:00:00.000000000Z", "caller":"emitter_test.go:21", "tags":{"allthese":"tags", "andanother":"tag"}, "message":"test"}` + "\n"
 	got := b.String()
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)
@@ -52,7 +53,7 @@ func TestCustomFieldNames(t *testing.T) {
 
 	l.Print(ctx, "test")
 
-	want := `{"ts":"0001-01-01T00:00:00.000000000Z", "called_at":"emitter_test.go:53", "msg":"test"}` + "\n"
+	want := `{"ts":"0001-01-01T00:00:00.000000000Z", "called_at":"emitter_test.go:54", "msg":"test"}` + "\n"
 	got := b.String()
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)
@@ -98,5 +99,32 @@ func TestHTMLNoEscape(t *testing.T) {
 	got := b.String()
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestDuplicateTag(t *testing.T) {
+	b := &bytes.Buffer{}
+	l := alog.New(alog.WithEmitter(Emitter(b, WithDateFormat(""))))
+
+	// If a caller adds some tags...
+	ctx := alog.AddTags(context.Background(), "a", "1", "b", "2")
+	// And then adds another tag with the same key...
+	ctx = alog.AddTags(ctx, "a", "3")
+	// Make sure only the latest one shows up...
+	l.Print(ctx, "")
+	const want = `{"tags":{"b":"2", "a":"3"}, "message":""}` + "\n"
+	if got := b.String(); got != want {
+		t.Errorf("got: %#q, want: %#q", got, want)
+	}
+	// And that it's valid json.
+	tgt := struct {
+		Message string
+		Tags    struct {
+			A string
+			B string
+		}
+	}{}
+	if err := json.Unmarshal(b.Bytes(), &tgt); err != nil {
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
The core alog package doesn't take a stance on duplicate tags and
they're simply passed through to emitters. In JSON, duplicate object
members are disallowed, meaning we were emitting invalid JSON.

This commit changes behavior to only use the last occurrence of a tag.