### PR TITLE
Add `go 1.12` to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/vimeo/alog/v3
+
+go 1.12


### PR DESCRIPTION
From the 1.12 release docs:
This changed use of the go directive means that if you use Go 1.12
to build a module, thus recording go 1.12 in the go.mod file, you
will get an error when attempting to build the same module with
Go 1.11 through Go 1.11.3. Go 1.11.4 or later will work fine, as
will releases older than Go 1.11. If you must use Go 1.11 through
1.11.3, you can avoid the problem by setting the language version
to 1.11, using the Go 1.12 go tool, via go mod edit -go=1.11.