### PR TITLE
Format httpHeader inner values as arrays

### DIFF
--- a/emitter/gkelog/emitter.go
+++ b/emitter/gkelog/emitter.go
@@ -275,18 +275,14 @@ func jsonHTTPRequest(ctx context.Context, w *bytes.Buffer) {
 			}
 			jsonKey(w, h)
 			v := request.Header[h]
-			if len(v) > 1 {
-				w.WriteByte('[')
-			}
+			w.WriteByte('[')
 			for j, v0 := range v {
 				if j > 0 {
 					w.WriteString(", ")
 				}
 				jsonString(w, v0)
 			}
-			if len(v) > 1 {
-				w.WriteByte(']')
-			}
+			w.WriteByte(']')
 			i++
 		}
 		w.WriteByte('}')

--- a/emitter/gkelog/emitter_test.go
+++ b/emitter/gkelog/emitter_test.go
@@ -100,11 +100,13 @@ func TestRequest(t *testing.T) {
 	req.Header.Set("X-Cloud-Trace-Context", "a2fbf27a2ed90077e0d4af0e40a241f9/12690385211238481741")
 	req.Header.Set("Content-Type", "text/plain")
 	req.Header.Set("Dnt", "1")
+	req.Header.Set("X-Varnish", "731698977")
+	req.Header.Add("X-Varnish", "4193052513")
 	ctx = WithRequest(ctx, req)
 
 	l.Print(ctx, "test")
 
-	want := `{"time":"0001-01-01T00:00:00Z", "httpRequest":{"requestMethod":"GET", "requestUrl":"/test/endpoint?q=1&c=pink", "userAgent":"curl/7.54.0", "referer":"https://vimeo.com"}, "httpHeaders":{"Content-Type":"text/plain", "Dnt":"1"}, "httpQuery":{"c":"pink", "q":"1"}, "logging.googleapis.com/trace":"a2fbf27a2ed90077e0d4af0e40a241f9", "logging.googleapis.com/spanId":"b01d4e1cf2bd7f4d", "logging.googleapis.com/trace_sampled":true, "message":"test"}` + "\n"
+	want := `{"time":"0001-01-01T00:00:00Z", "httpRequest":{"requestMethod":"GET", "requestUrl":"/test/endpoint?q=1&c=pink", "userAgent":"curl/7.54.0", "referer":"https://vimeo.com"}, "httpHeaders":{"Content-Type":["text/plain"], "Dnt":["1"], "X-Varnish":["731698977", "4193052513"]}, "httpQuery":{"c":"pink", "q":"1"}, "logging.googleapis.com/trace":"a2fbf27a2ed90077e0d4af0e40a241f9", "logging.googleapis.com/spanId":"b01d4e1cf2bd7f4d", "logging.googleapis.com/trace_sampled":true, "message":"test"}` + "\n"
 	got := b.String()
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)


### PR DESCRIPTION
The type of `http.Header` is `map[string][]string`, but currently, `alog` only writes headers with multiple values as an array. This update ensures that all http.Header inner values are arrays.