### PR TITLE
Format httpQuery inner values as arrays

### DIFF
--- a/emitter/gkelog/emitter.go
+++ b/emitter/gkelog/emitter.go
@@ -300,18 +300,14 @@ func jsonHTTPRequest(ctx context.Context, w *bytes.Buffer) {
 			}
 			jsonKey(w, q)
 			v := query[q]
-			if len(v) > 1 {
-				w.WriteByte('[')
-			}
+			w.WriteByte('[')
 			for j, v0 := range v {
 				if j > 0 {
 					w.WriteString(", ")
 				}
 				jsonString(w, v0)
 			}
-			if len(v) > 1 {
-				w.WriteByte(']')
-			}
+			w.WriteByte(']')
 		}
 		w.WriteByte('}')
 		w.WriteString(", ")

--- a/emitter/gkelog/emitter_test.go
+++ b/emitter/gkelog/emitter_test.go
@@ -94,7 +94,7 @@ func TestRequest(t *testing.T) {
 	ctx := context.Background()
 	l := alog.New(alog.WithEmitter(Emitter(WithWriter(b))), zeroTimeOpt)
 
-	req := httptest.NewRequest(http.MethodGet, "/test/endpoint?q=1&c=pink", strings.NewReader("this is a test"))
+	req := httptest.NewRequest(http.MethodGet, "/test/endpoint?q=1&c=pink&c=red", strings.NewReader("this is a test"))
 	req.Header.Set("User-Agent", "curl/7.54.0")
 	req.Header.Set("Referer", "https://vimeo.com")
 	req.Header.Set("X-Cloud-Trace-Context", "a2fbf27a2ed90077e0d4af0e40a241f9/12690385211238481741")
@@ -106,7 +106,7 @@ func TestRequest(t *testing.T) {
 
 	l.Print(ctx, "test")
 
-	want := `{"time":"0001-01-01T00:00:00Z", "httpRequest":{"requestMethod":"GET", "requestUrl":"/test/endpoint?q=1&c=pink", "userAgent":"curl/7.54.0", "referer":"https://vimeo.com"}, "httpHeaders":{"Content-Type":["text/plain"], "Dnt":["1"], "X-Varnish":["731698977", "4193052513"]}, "httpQuery":{"c":"pink", "q":"1"}, "logging.googleapis.com/trace":"a2fbf27a2ed90077e0d4af0e40a241f9", "logging.googleapis.com/spanId":"b01d4e1cf2bd7f4d", "logging.googleapis.com/trace_sampled":true, "message":"test"}` + "\n"
+	want := `{"time":"0001-01-01T00:00:00Z", "httpRequest":{"requestMethod":"GET", "requestUrl":"/test/endpoint?q=1&c=pink&c=red", "userAgent":"curl/7.54.0", "referer":"https://vimeo.com"}, "httpHeaders":{"Content-Type":["text/plain"], "Dnt":["1"], "X-Varnish":["731698977", "4193052513"]}, "httpQuery":{"c":["pink", "red"], "q":["1"]}, "logging.googleapis.com/trace":"a2fbf27a2ed90077e0d4af0e40a241f9", "logging.googleapis.com/spanId":"b01d4e1cf2bd7f4d", "logging.googleapis.com/trace_sampled":true, "message":"test"}` + "\n"
 	got := b.String()
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)


### PR DESCRIPTION
The type of http query `Values` is `map[string][]string`, but currently, alog only writes query parameters with multiple values as an array. This update ensures that all http query inner values are arrays.