### PR TITLE
Support Structured Tags

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,28 +1,55 @@
 package alog
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+)
 
 type key struct{}
 
 var ctxkey = &key{}
+
+// Tag contains a key and value associated with a log message.  Its value may be
+// JSON which may be important to some emitters.
+type Tag struct {
+	Key    string
+	Value  string
+	IsJSON bool
+}
 
 // AddTags adds paired strings to the set of tags in the Context.
 //
 // Any unpaired strings are ignored.
 func AddTags(ctx context.Context, pairs ...string) context.Context {
 	old := fromContext(ctx)
-	new := make([][2]string, len(old)+(len(pairs)/2))
+	new := make([]Tag, len(old)+(len(pairs)/2))
 	copy(new, old)
 	for o := range new[len(old):] {
-		new[len(old)+o][0] = pairs[o*2]
-		new[len(old)+o][1] = pairs[o*2+1]
+		new[len(old)+o] = Tag{
+			Key:    pairs[o*2],
+			Value:  pairs[o*2+1],
+			IsJSON: isJSONStructure(pairs[o*2+1]),
+		}
 	}
 	return context.WithValue(ctx, ctxkey, new)
 }
 
+// isJSON checks to make sure the input is valid JSON and is either an array or
+// object literal.  Note that json.Valid returns true for numeric literals like
+// 42.
+func isJSONStructure(value string) bool {
+	maybeJSON := false
+	if len(value) > 0 {
+		if value[0] == '{' || value[0] == '[' {
+			maybeJSON = true
+		}
+	}
+	return maybeJSON && json.Valid([]byte(value))
+}
+
 // fromContext wraps the type assertion coming out of a Context.
-func fromContext(ctx context.Context) [][2]string {
-	if t, ok := ctx.Value(ctxkey).([][2]string); ok {
+func fromContext(ctx context.Context) []Tag {
+	if t, ok := ctx.Value(ctxkey).([]Tag); ok {
 		return t
 	}
 	return nil

--- a/emitter/gkelog/emitter.go
+++ b/emitter/gkelog/emitter.go
@@ -359,14 +359,18 @@ func Emitter(opt ...Option) alog.Emitter {
 
 		tagClean := make(map[string]int, len(e.Tags))
 		for i, tag := range e.Tags {
-			tagClean[tag[0]] = i
+			tagClean[tag.Key] = i
 		}
 		for i, tag := range e.Tags {
-			if tagClean[tag[0]] != i || reservedKeys[tag[0]] {
+			if tagClean[tag.Key] != i || reservedKeys[tag.Key] {
 				continue
 			}
-			jsonKey(b, tag[0])
-			jsonString(b, tag[1])
+			jsonKey(b, tag.Key)
+			if tag.IsJSON {
+				b.WriteString(tag.Value)
+			} else {
+				jsonString(b, tag.Value)
+			}
 			b.WriteString(", ")
 		}
 

--- a/emitter/gkelog/emitter_test.go
+++ b/emitter/gkelog/emitter_test.go
@@ -49,10 +49,10 @@ func TestLabels(t *testing.T) {
 	ctx := context.Background()
 	l := alog.New(alog.WithEmitter(Emitter(WithWriter(b))), zeroTimeOpt)
 
-	ctx = alog.AddTags(ctx, "allthese", "tags", "andanother", "tag")
+	ctx = alog.AddTags(ctx, "allthese", "tags", "andanother", "tag", "struct", `{"x": {"y": 2}, "z": 1}`, "invalidJSON", `{"x}`)
 	l.Print(ctx, "test")
 
-	want := `{"time":"0001-01-01T00:00:00Z", "allthese":"tags", "andanother":"tag", "message":"test"}` + "\n"
+	want := `{"time":"0001-01-01T00:00:00Z", "allthese":"tags", "andanother":"tag", "struct":{"x": {"y": 2}, "z": 1}, "invalidJSON":"{\"x}", "message":"test"}` + "\n"
 	got := b.String()
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)

--- a/emitter/jsonlog/emitter.go
+++ b/emitter/jsonlog/emitter.go
@@ -110,15 +110,19 @@ func Emitter(w io.Writer, opt ...Option) alog.Emitter {
 			b.WriteString(`"tags":{`)
 			tagClean := make(map[string]int, len(e.Tags))
 			for i, tag := range e.Tags {
-				tagClean[tag[0]] = i
+				tagClean[tag.Key] = i
 			}
 			for i, tag := range e.Tags {
-				if tagClean[tag[0]] != i {
+				if tagClean[tag.Key] != i {
 					continue
 				}
-				jsonString(b, tag[0])
+				jsonString(b, tag.Key)
 				b.WriteByte(':')
-				jsonString(b, tag[1])
+				if tag.IsJSON {
+					b.WriteString(tag.Value)
+				} else {
+					jsonString(b, tag.Value)
+				}
 				if i < len(e.Tags)-1 {
 					b.WriteString(", ")
 				}

--- a/emitter/jsonlog/emitter_test.go
+++ b/emitter/jsonlog/emitter_test.go
@@ -107,12 +107,12 @@ func TestDuplicateTag(t *testing.T) {
 	l := alog.New(alog.WithEmitter(Emitter(b, WithDateFormat(""))))
 
 	// If a caller adds some tags...
-	ctx := alog.AddTags(context.Background(), "a", "1", "b", "2")
+	ctx := alog.AddTags(context.Background(), "a", "1", "b", "2", "c", `{"x": 1}`)
 	// And then adds another tag with the same key...
 	ctx = alog.AddTags(ctx, "a", "3")
 	// Make sure only the latest one shows up...
 	l.Print(ctx, "")
-	const want = `{"tags":{"b":"2", "a":"3"}, "message":""}` + "\n"
+	const want = `{"tags":{"b":"2", "c":{"x": 1}, "a":"3"}, "message":""}` + "\n"
 	if got := b.String(); got != want {
 		t.Errorf("got: %#q, want: %#q", got, want)
 	}
@@ -122,9 +122,15 @@ func TestDuplicateTag(t *testing.T) {
 		Tags    struct {
 			A string
 			B string
+			C struct {
+				X int
+			}
 		}
 	}{}
 	if err := json.Unmarshal(b.Bytes(), &tgt); err != nil {
 		t.Error(err)
+	}
+	if tgt.Tags.C.X != 1 {
+		t.Errorf("expected X to be 1, instead: %d", tgt.Tags.C.X)
 	}
 }

--- a/emitter/textlog/emitter.go
+++ b/emitter/textlog/emitter.go
@@ -58,9 +58,9 @@ func Emitter(w io.Writer, opt ...Option) alog.Emitter {
 				if i != 0 {
 					m.WriteByte(' ')
 				}
-				m.WriteString(p[0])
+				m.WriteString(p.Key)
 				m.WriteByte('=')
-				m.WriteString(p[1])
+				m.WriteString(p.Value)
 			}
 			m.WriteString("] ")
 		}

--- a/entry.go
+++ b/entry.go
@@ -5,7 +5,7 @@ import "time"
 // Entry is the struct passed to user-supplied formatters.
 type Entry struct {
 	Time time.Time
-	Tags [][2]string
+	Tags []Tag
 	File string
 	Line int
 	Msg  string


### PR DESCRIPTION
- change the tag type from a simple two-string tuple to a struct
- check when the Tag is added if its value is a valid JSON object or array and store the result of that calculation.
- for structured loggers like JSON and GKE, avoid escaping tags that are already valid JSON.