### PR TITLE
Update Go Versions 2024 August Edition

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,38 +8,30 @@ jobs:
     strategy:
       matrix:
         os:  [macOS-latest, ubuntu-latest]
-        goversion: [1.12, 1.13]
+        goversion: ['1.20', '1.21', '1.22']
     steps:
 
     - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v5
       with:
         go-version: ${{matrix.goversion}}
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     
     - name: gofmt
       run: |
         [[ -z $(gofmt -l $(find . -name '*go') ) ]]
 
     - name: Get dependencies
-      env:
-        GO111MODULE: on
       run: go mod download
 
     - name: Vet
-      env:
-        GO111MODULE: on
       run: go vet -mod=readonly ./...
       
     - name: Test
-      env:
-        GO111MODULE: on
       run: go test -mod=readonly ./...
     
     - name: Race Test
-      env:
-        GO111MODULE: on
       run: go test -race -mod=readonly -v -count 2 ./...


### PR DESCRIPTION
Update the tests to run against the last three minor versions of Go.